### PR TITLE
Release v0.1.6

### DIFF
--- a/user_notifications/__version__.py
+++ b/user_notifications/__version__.py
@@ -1,1 +1,1 @@
-VERSION="0.1.5"
+VERSION="0.1.6"


### PR DESCRIPTION
Notes:

- Added Exceptions to `save_user_acknowledgement` to see if user has already accepted the notification or if for some reason there are more then one messages for that notification that have not been confirmed
<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>